### PR TITLE
fix: 添加导航栏监听，避免隐藏导航栏的弹框已弹出的状态下，再次弹出会显示导航栏

### DIFF
--- a/library/src/main/java/com/lxj/xpopup/core/FullScreenDialog.java
+++ b/library/src/main/java/com/lxj/xpopup/core/FullScreenDialog.java
@@ -84,7 +84,25 @@ public class FullScreenDialog extends Dialog {
 
         //自动设置状态色调，亮色还是暗色
         autoSetStatusBarMode();
+        initListener();
         setContentView(contentView);
+    }
+
+    private void initListener() {
+        final ViewGroup decorView = (ViewGroup) getWindow().getDecorView();
+        decorView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
+            @Override
+            public void onSystemUiVisibilityChange(int visibility) {
+                if (!contentView.popupInfo.hasNavigationBar) {
+                    hideNavigationBar();
+                }
+                if (!contentView.popupInfo.hasStatusBar) {
+                    getWindow().setFlags(
+                            WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                            WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                }
+            }
+        });
     }
 
     public boolean isFuckVIVORoom(){


### PR DESCRIPTION
作者你好~

使用过程中，发现若弹框均设置隐藏导航栏和状态栏后，在已有弹框的基础上再次弹框，导航栏会重新出现，因此在 FullScreenDialog 中添加 SystemUi 可见性监听，根据配置执行隐藏状态栏和导航栏逻辑。