### PR TITLE
修正4.4设备运行崩溃问题；优化气泡布局居中显示位置计算规则

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view-androidx:3.10.0'
     implementation 'com.github.mmin18:realtimeblurview:1.2.1'
+    annotationProcessor "androidx.lifecycle:lifecycle-compiler:2.3.1"
 }


### PR DESCRIPTION
1、修正4.4设备运行崩溃问题
https://github.com/li-xiaojun/XPopup/issues/1071
2、优化居中气泡显示超出屏幕时的平移计算规则
如果气泡设置居中显示，那么当气泡左侧超出屏幕时，修改为对齐atView的左侧显示；相反如果气泡右侧超出屏幕时，修改为对齐atView的右侧显示；当左侧和右侧都没超出或者都超出时，还是居中显示